### PR TITLE
Add option to override the button type and how it's presented

### DIFF
--- a/Ibralogue/Examples/ExampleScenes/ExampleScene.unity
+++ b/Ibralogue/Examples/ExampleScenes/ExampleScene.unity
@@ -1004,8 +1004,8 @@ MonoBehaviour:
   choiceButton: {fileID: 6826497581176721296, guid: b6c33d346da503441b5a598f8ac974a2, type: 3}
   searchAllAssemblies: 0
   includedAssemblies:
-  - Interactions
-  - Examples
+  - Ibralogue.Interactions
+  - Ibralogue.Examples
 --- !u!1 &1681295512
 GameObject:
   m_ObjectHideFlags: 0

--- a/Ibralogue/Examples/ExampleScenes/ExampleScene.unity
+++ b/Ibralogue/Examples/ExampleScenes/ExampleScene.unity
@@ -1003,7 +1003,9 @@ MonoBehaviour:
   choiceButtonHolder: {fileID: 26815127}
   choiceButton: {fileID: 6826497581176721296, guid: b6c33d346da503441b5a598f8ac974a2, type: 3}
   searchAllAssemblies: 0
-  includedAssemblies: []
+  includedAssemblies:
+  - Interactions
+  - Examples
 --- !u!1 &1681295512
 GameObject:
   m_ObjectHideFlags: 0

--- a/Ibralogue/Examples/ExampleScenes/ExampleScene.unity
+++ b/Ibralogue/Examples/ExampleScenes/ExampleScene.unity
@@ -43,7 +43,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
+  serializedVersion: 12
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_LightingSettings: {fileID: 2011610391}
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -118,6 +118,8 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -148,6 +150,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 91.18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 34741671}
   m_RootOrder: 2
@@ -182,6 +185,7 @@ MonoBehaviour:
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &34741667
 GameObject:
   m_ObjectHideFlags: 0
@@ -240,6 +244,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!223 &34741670
 Canvas:
   m_ObjectHideFlags: 0
@@ -271,6 +276,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 371977644}
   - {fileID: 1694175707}
@@ -314,6 +320,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1062356647}
   m_Father: {fileID: 34741671}
@@ -338,6 +345,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -368,6 +376,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 371977649}
+        m_TargetAssemblyTypeName: 
         m_MethodName: StartDialogue
         m_Mode: 1
         m_Arguments:
@@ -393,6 +402,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -427,13 +437,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cca3e122dce1f9d498ac3c22715a2ced, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  dialogueManager: {fileID: 1515395011}
+  dialogueManager: {fileID: 1515395013}
   InteractionDialogues:
-  - {fileID: 3232733424486734734, guid: c73a8071bc1840c48833c2a801557459, type: 3}
+  - {fileID: 3232733424486734734, guid: 2922fc19c5b85454b90752116b3d59d6, type: 3}
   OnDialogueStart:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 371977643}
+        m_TargetAssemblyTypeName: 
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
@@ -448,6 +459,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 371977643}
+        m_TargetAssemblyTypeName: 
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
@@ -539,6 +551,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -570,6 +583,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 480.73618, y: 427.44223, z: -82.53002}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -586,7 +600,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 44147194856e88a469e327aa70a5ecdb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  dialogueManager: {fileID: 1515395011}
+  dialogueManager: {fileID: 1515395013}
 --- !u!1 &562461647
 GameObject:
   m_ObjectHideFlags: 0
@@ -615,6 +629,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 34741671}
   m_RootOrder: 3
@@ -639,6 +654,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -689,6 +705,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1694175707}
   m_RootOrder: 1
@@ -713,6 +730,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -827,6 +845,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 371977644}
   m_RootOrder: 0
@@ -851,6 +870,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -941,7 +961,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1515395012}
-  - component: {fileID: 1515395011}
+  - component: {fileID: 1515395013}
   m_Layer: 0
   m_Name: DialogueManager
   m_TagString: Untagged
@@ -949,28 +969,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1515395011
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1515395010}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30c15883baf93e446a1872a3f011d140, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  scrollSpeed: 25
-  nameText: {fileID: 1681295514}
-  sentenceText: {fileID: 575064700}
-  speakerPortrait: {fileID: 562461649}
-  choiceButtonHolder: {fileID: 26815127}
-  choiceButton: {fileID: 6826497581176721293, guid: b6c33d346da503441b5a598f8ac974a2, type: 3}
-  searchAllAssemblies: 0
-  includedAssemblies:
-  - Interactions
-  - Examples
 --- !u!4 &1515395012
 Transform:
   m_ObjectHideFlags: 0
@@ -981,10 +979,31 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 40.60215, y: 14.064223, z: -71.92932}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1515395013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1515395010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e052bcdf6a3fa4b42ae0a9a6adff16a5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scrollSpeed: 25
+  nameText: {fileID: 1681295514}
+  sentenceText: {fileID: 575064700}
+  speakerPortrait: {fileID: 562461649}
+  choiceButtonHolder: {fileID: 26815127}
+  choiceButton: {fileID: 6826497581176721296, guid: b6c33d346da503441b5a598f8ac974a2, type: 3}
+  searchAllAssemblies: 0
+  includedAssemblies: []
 --- !u!1 &1681295512
 GameObject:
   m_ObjectHideFlags: 0
@@ -1013,6 +1032,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0.06104851, w: 0.99813485}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1694175707}
   m_RootOrder: 0
@@ -1037,6 +1057,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1146,6 +1167,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1681295513}
   - {fileID: 575064699}
@@ -1172,6 +1194,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1224,6 +1247,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -1256,7 +1280,70 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!850595691 &2011610391
+LightingSettings:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Settings.lighting
+  serializedVersion: 4
+  m_GIWorkflowMode: 1
+  m_EnableBakedLightmaps: 0
+  m_EnableRealtimeLightmaps: 0
+  m_RealtimeEnvironmentLighting: 1
+  m_BounceScale: 1
+  m_AlbedoBoost: 1
+  m_IndirectOutputScale: 1
+  m_UsingShadowmask: 1
+  m_BakeBackend: 0
+  m_LightmapMaxSize: 1024
+  m_BakeResolution: 40
+  m_Padding: 2
+  m_LightmapCompression: 3
+  m_AO: 0
+  m_AOMaxDistance: 1
+  m_CompAOExponent: 1
+  m_CompAOExponentDirect: 0
+  m_ExtractAO: 0
+  m_MixedBakeMode: 2
+  m_LightmapsBakeMode: 1
+  m_FilterMode: 1
+  m_LightmapParameters: {fileID: 15204, guid: 0000000000000000f000000000000000, type: 0}
+  m_ExportTrainingData: 0
+  m_TrainingDataDestination: TrainingData
+  m_RealtimeResolution: 2
+  m_ForceWhiteAlbedo: 0
+  m_ForceUpdates: 0
+  m_FinalGather: 0
+  m_FinalGatherRayCount: 256
+  m_FinalGatherFiltering: 1
+  m_PVRCulling: 1
+  m_PVRSampling: 1
+  m_PVRDirectSampleCount: 32
+  m_PVRSampleCount: 500
+  m_PVREnvironmentSampleCount: 500
+  m_PVREnvironmentReferencePointCount: 2048
+  m_LightProbeSampleCountMultiplier: 4
+  m_PVRBounces: 2
+  m_PVRMinBounces: 2
+  m_PVREnvironmentMIS: 0
+  m_PVRFilteringMode: 2
+  m_PVRDenoiserTypeDirect: 0
+  m_PVRDenoiserTypeIndirect: 0
+  m_PVRDenoiserTypeAO: 0
+  m_PVRFilterTypeDirect: 0
+  m_PVRFilterTypeIndirect: 0
+  m_PVRFilterTypeAO: 0
+  m_PVRFilteringGaussRadiusDirect: 1
+  m_PVRFilteringGaussRadiusIndirect: 5
+  m_PVRFilteringGaussRadiusAO: 2
+  m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+  m_PVRFilteringAtrousPositionSigmaIndirect: 2
+  m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_PVRTiledBaking: 0

--- a/Ibralogue/Examples/ExampleScripts/DialogueInput.cs
+++ b/Ibralogue/Examples/ExampleScripts/DialogueInput.cs
@@ -4,7 +4,7 @@ namespace Ibralogue.Examples
 {
     public class DialogueInput : MonoBehaviour
     {
-        [SerializeField] private DialogueManager dialogueManager;
+        [SerializeField] private DefaultDialogueManager dialogueManager;
         private void Update()
         {
             if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter))

--- a/Ibralogue/Scripts/Core/AssemblyInfo.cs
+++ b/Ibralogue/Scripts/Core/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Ibralogue.Editor")]

--- a/Ibralogue/Scripts/Core/AssemblyInfo.cs.meta
+++ b/Ibralogue/Scripts/Core/AssemblyInfo.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 30c15883baf93e446a1872a3f011d140
+guid: 76218b95e9ce8a24abd9818dfc3d9079
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Ibralogue/Scripts/Core/DefaultDialogueManager.cs
+++ b/Ibralogue/Scripts/Core/DefaultDialogueManager.cs
@@ -5,7 +5,6 @@ using UnityEngine.UI;
 
 namespace Ibralogue
 {
-
     public class DefaultDialogueManager : DialogueManagerBase<Button>
     {
         protected override void PrepareChoiceButton(ChoiceButtonHandle handle, Choice choice)

--- a/Ibralogue/Scripts/Core/DefaultDialogueManager.cs
+++ b/Ibralogue/Scripts/Core/DefaultDialogueManager.cs
@@ -1,0 +1,17 @@
+using Ibralogue.Parser;
+using System.Runtime.CompilerServices;
+using TMPro;
+using UnityEngine.UI;
+
+namespace Ibralogue
+{
+
+    public class DefaultDialogueManager : DialogueManagerBase<Button>
+    {
+        protected override void PrepareChoiceButton(ChoiceButtonHandle handle, Choice choice)
+        {
+            handle.ChoiceButton.GetComponentInChildren<TextMeshProUGUI>().text = choice.ChoiceName;
+            handle.ClickEvent = handle.ChoiceButton.onClick;
+        }
+    }
+}

--- a/Ibralogue/Scripts/Core/DefaultDialogueManager.cs.meta
+++ b/Ibralogue/Scripts/Core/DefaultDialogueManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e052bcdf6a3fa4b42ae0a9a6adff16a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Ibralogue/Scripts/Core/DialogueManagerBase.cs.meta
+++ b/Ibralogue/Scripts/Core/DialogueManagerBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c39b418f86bfcbc4c8fa4f8f394dcf96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Ibralogue/Scripts/Core/Parser/DialogueParser.cs
+++ b/Ibralogue/Scripts/Core/Parser/DialogueParser.cs
@@ -268,7 +268,7 @@ namespace Ibralogue
          foreach (Match match in VariableRegex.Matches(line))
          {
             string processedVariable = match.ToString().Trim().Replace("$", string.Empty);
-            if (DialogueManager.GlobalVariables.TryGetValue(processedVariable, out string keyValue))
+            if (DialogueGlobals.GlobalVariables.TryGetValue(processedVariable, out string keyValue))
             {
                line = line.Replace(match.ToString(), keyValue);
             }

--- a/Ibralogue/Scripts/Interactions/BaseInteraction.cs
+++ b/Ibralogue/Scripts/Interactions/BaseInteraction.cs
@@ -9,7 +9,7 @@ namespace Ibralogue.Interactions
     /// </summary>
     public abstract class BaseInteraction : MonoBehaviour
     {
-        [SerializeField] protected DialogueManager dialogueManager;
+        [SerializeField] protected DefaultDialogueManager dialogueManager;
         [SerializeField] protected DialogueAsset[] InteractionDialogues;
 
         [SerializeField] private UnityEvent OnDialogueStart;


### PR DESCRIPTION
The changes introduce the ` DialogueManagerBase ` which abstract ` PrepareChoiceButton ` and a generic ` ChoiceButtonT `. That allows for overriding the way the library shows choices to support new features like button icons.

This PR also adds ` DefaultDialogueManager ` which implements the current behaviour.

Migration Guide:
- Replace every DialogueManager with DefaultDialogueManager

> Note:
> *This is not how the system should look in the end but it is a step towards a more flexible approach*