### PR TITLE
Fix: Choices in the first line of the sentence are not shown

### DIFF
--- a/Ibralogue/Scripts/Core/DialogueManagerBase.cs
+++ b/Ibralogue/Scripts/Core/DialogueManagerBase.cs
@@ -77,6 +77,15 @@ namespace Ibralogue
         /// </summary>
         private IEnumerator DisplayDialogue()
         {
+            if (_currentConversation.Choices != null && _currentConversation.Choices.Count > 0)
+            {
+                if (_dialogueIndex == _currentConversation.Choices
+                        .FirstOrDefault(x => x.Value == _dialogueIndex).Value)
+                {
+                    DisplayChoices();
+                }
+            }
+
             nameText.text = _currentConversation.Lines[_dialogueIndex].Speaker;
             _linePlaying = true;
             sentenceText.text = _currentConversation.Lines[_dialogueIndex].LineContent.Text;
@@ -132,14 +141,6 @@ namespace Ibralogue
             {
                 _dialogueIndex++;
                 StartCoroutine(DisplayDialogue());
-                if (_currentConversation.Choices != null && _currentConversation.Choices.Count > 0)
-                {
-                    if (_dialogueIndex == _currentConversation.Choices
-                            .FirstOrDefault(x => x.Value == _dialogueIndex).Value)
-                    {
-                        DisplayChoices();
-                    }
-                }
             }
             else
             {


### PR DESCRIPTION
As title suggests, the fix corrects the issue where choice are not displayed when calling Start Conversation