### PR TITLE
Implement "No target" for the choices and reserve "Continue" keyword for future use

### DIFF
--- a/Ibralogue/Scripts/Core/DialogueManagerBase.cs
+++ b/Ibralogue/Scripts/Core/DialogueManagerBase.cs
@@ -158,17 +158,26 @@ namespace Ibralogue
             {
                 var choiceButtonInstance = CreateChoiceButton();
 
+                UnityAction onClickAction = null;
                 int conversationIndex = -1;
-                if (choice.LeadingConversationName != "__") // TODO: Consider providing a place to change the keyword
+                switch (choice.LeadingConversationName)
                 {
-                    conversationIndex = ParsedConversations.FindIndex(c => c.Name == choice.LeadingConversationName);
-                    if (conversationIndex == -1)
-                        DialogueLogger.LogError(2, $"No conversation called \"{choice.LeadingConversationName}\" found for choice \"{choice.ChoiceName}\" in \"{_currentConversation.Name}\".", this);
+                    case ">>": // TODO: Consider providing a place to change the keyword
+                        DialogueLogger.LogError(2, "The embedded choice is not yet implemented, '>>' keyword is reserved for future use");
+                        goto case "__";
+
+                    case "__": // TODO: Consider providing a place to change the keyword
+                        onClickAction = () => { };
+                        break;
+
+                    default:
+                        conversationIndex = ParsedConversations.FindIndex(c => c.Name == choice.LeadingConversationName);
+                        if (conversationIndex == -1)
+                            DialogueLogger.LogError(2, $"No conversation called \"{choice.LeadingConversationName}\" found for choice \"{choice.ChoiceName}\" in \"{_currentConversation.Name}\".", this);
+                        onClickAction = () => StartConversation(ParsedConversations[conversationIndex]);
+                        break;
                 }
 
-                UnityAction onClickAction = conversationIndex >= 0
-                    ? () => StartConversation(ParsedConversations[conversationIndex])
-                    : () => { };
 
                 var handle = new ChoiceButtonHandle(
                     choiceButtonInstance,

--- a/Ibralogue/Scripts/Core/DialogueManagerBase.cs
+++ b/Ibralogue/Scripts/Core/DialogueManagerBase.cs
@@ -162,11 +162,11 @@ namespace Ibralogue
                 int conversationIndex = -1;
                 switch (choice.LeadingConversationName)
                 {
-                    case ">>": // TODO: Consider providing a place to change the keyword
+                    case ">>":
                         DialogueLogger.LogError(2, "The embedded choice is not yet implemented, '>>' keyword is reserved for future use");
                         goto case "__";
 
-                    case "__": // TODO: Consider providing a place to change the keyword
+                    case "__":
                         onClickAction = () => { };
                         break;
 

--- a/Ibralogue/Scripts/Core/DialogueManagerBase.cs
+++ b/Ibralogue/Scripts/Core/DialogueManagerBase.cs
@@ -158,13 +158,21 @@ namespace Ibralogue
             {
                 var choiceButtonInstance = CreateChoiceButton();
 
-                int conversationIndex = ParsedConversations.FindIndex(c => c.Name == choice.LeadingConversationName);
-                if (conversationIndex == -1)
-                    DialogueLogger.LogError(2, $"No conversation called \"{choice.LeadingConversationName}\" found for choice \"{choice.ChoiceName}\" in \"{_currentConversation.Name}\".", this);
+                int conversationIndex = -1;
+                if (choice.LeadingConversationName != "__") // TODO: Consider providing a place to change the keyword
+                {
+                    conversationIndex = ParsedConversations.FindIndex(c => c.Name == choice.LeadingConversationName);
+                    if (conversationIndex == -1)
+                        DialogueLogger.LogError(2, $"No conversation called \"{choice.LeadingConversationName}\" found for choice \"{choice.ChoiceName}\" in \"{_currentConversation.Name}\".", this);
+                }
+
+                UnityAction onClickAction = conversationIndex >= 0
+                    ? () => StartConversation(ParsedConversations[conversationIndex])
+                    : () => { };
 
                 var handle = new ChoiceButtonHandle(
                     choiceButtonInstance,
-                    () => StartConversation(ParsedConversations[conversationIndex])
+                    onClickAction
                 );
 
                 _choiceButtonInstances.Add(handle);
@@ -270,8 +278,8 @@ namespace Ibralogue
             public UnityEvent ClickEvent { get; set; }
 
             public ChoiceButtonT ChoiceButton { get; private set; }
-            public UnityAction ClickCallback { get;  private set; }
-            
+            public UnityAction ClickCallback { get; private set; }
+
         }
     }
 }


### PR DESCRIPTION
This PR introduces two keyword that should be used with choices instead of the conversation name.
- ` __ ` (two underscores) which means "this choice does nothing" and is meant to be paired with metadata
- ` >> ` which means "the conversation should continue" and is reserved for future use

Note: The latter is not yet implemented due to technical difficulties with parsing

Example syntax assuming both features are implemented
```
[NPC]
Hey, how are you?
- Fine -> >>
- I'm not well, I've been panicking all day -> Panic
- I just need a moment -> __  ## moment-of-silence
```