### PR TITLE
Choice button rework

### DIFF
--- a/Editor/Templates/DefaultDialogue.ibra.txt
+++ b/Editor/Templates/DefaultDialogue.ibra.txt
@@ -1,4 +1,3 @@
-{{DialogueName(Init)}}
 [NPC]
 Hello World!
 {{DialogueEnd}}

--- a/Runtime/Dialogue Managers/DialogueManagerBase.cs
+++ b/Runtime/Dialogue Managers/DialogueManagerBase.cs
@@ -1,4 +1,5 @@
 ﻿using Ibralogue.Parser;
+using Ibralogue.UI;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -16,7 +17,7 @@ namespace Ibralogue
         public static readonly Dictionary<string, string> GlobalVariables = new Dictionary<string, string>();
     }
 
-    public abstract class DialogueManagerBase<ChoiceButtonT> : MonoBehaviour where ChoiceButtonT : Component
+    public abstract class DialogueManagerBase : MonoBehaviour
     {
         public UnityEvent OnConversationStart { get; set; } = new UnityEvent();
         public UnityEvent OnConversationEnd { get; set; } = new UnityEvent();
@@ -36,8 +37,8 @@ namespace Ibralogue
         [SerializeField] protected Image speakerPortrait;
 
         [Header("Choice UI")][SerializeField] protected Transform choiceButtonHolder;
-        [SerializeField] protected ChoiceButtonT choiceButton;
-        protected List<ChoiceButtonHandle> _choiceButtonInstances = new List<ChoiceButtonHandle>();
+        [SerializeField] protected ChoiceButton choiceButton;
+        protected List<ChoiceButton> _choiceButtonInstances = new List<ChoiceButton>();
 
         [Header("Function Invocations")]
         [SerializeField]
@@ -211,7 +212,7 @@ namespace Ibralogue
             if (_currentConversation.Choices == null || !_currentConversation.Choices.Any()) return;
             foreach (Choice choice in _currentConversation.Choices.Keys)
             {
-                ChoiceButtonT choiceButtonInstance = CreateChoiceButton();
+                ChoiceButton choiceButtonInstance = Instantiate(choiceButton, choiceButtonHolder);
 
                 UnityAction onClickAction = null;
                 int conversationIndex = -1;
@@ -234,20 +235,17 @@ namespace Ibralogue
                 }
 
 
-                ChoiceButtonHandle handle = new ChoiceButtonHandle(
-                    choiceButtonInstance,
-                    onClickAction
-                );
+                //ChoiceButtonHandle handle = new ChoiceButtonHandle(
+                //    choiceButtonInstance,
+                //    onClickAction
+                //);
 
-                _choiceButtonInstances.Add(handle);
-                PrepareChoiceButton(handle, choice);
+                _choiceButtonInstances.Add(choiceButtonInstance);
 
                 choiceButtonInstance.GetComponentInChildren<TextMeshProUGUI>().text = choice.ChoiceName;
-                handle.ClickEvent.AddListener(handle.ClickCallback);
+                choiceButton.ClickEvent.AddListener(choiceButton.ClickCallback);
             }
         }
-
-        protected abstract void PrepareChoiceButton(ChoiceButtonHandle handle, Choice choice);
 
         /// <summary>
         /// Gets all methods for the current assembly, other specified assemblies, or all assemblies, and checks them against the
@@ -303,44 +301,13 @@ namespace Ibralogue
             if (_choiceButtonInstances == null)
                 return;
 
-            foreach (ChoiceButtonHandle buttonHandle in _choiceButtonInstances)
+            foreach (ChoiceButton choiceButton in _choiceButtonInstances)
             {
-                ClearChoiceButton(buttonHandle);
-                RemoveChoiceButton(buttonHandle);
+                //choiceButton.ClickEvent.RemoveListener(choiceButton.ClickCallback);
+                Destroy(choiceButton.gameObject);
             }
 
             _choiceButtonInstances.Clear();
-        }
-
-        protected virtual ChoiceButtonT CreateChoiceButton()
-        {
-            return Instantiate(choiceButton, choiceButtonHolder);
-        }
-
-        protected virtual void ClearChoiceButton(ChoiceButtonHandle buttonHandle)
-        {
-            buttonHandle.ClickEvent.RemoveListener(buttonHandle.ClickCallback);
-        }
-
-        protected virtual void RemoveChoiceButton(ChoiceButtonHandle buttonHandle)
-        {
-            Destroy(buttonHandle.ChoiceButton.gameObject);
-        }
-
-        /// <summary>
-        /// Represent a single spawned choice button, contains general information about said button
-        /// </summary>
-        protected class ChoiceButtonHandle
-        {
-            public ChoiceButtonHandle(ChoiceButtonT choiceButton, UnityAction clickCallback)
-            {
-                ChoiceButton = choiceButton;
-                ClickCallback = clickCallback;
-            }
-
-            public UnityEvent ClickEvent { get; set; }
-            public ChoiceButtonT ChoiceButton { get; private set; }
-            public UnityAction ClickCallback { get; private set; }
         }
     }
 }

--- a/Runtime/Dialogue Managers/DialogueManagerBase.cs
+++ b/Runtime/Dialogue Managers/DialogueManagerBase.cs
@@ -37,7 +37,7 @@ namespace Ibralogue
         [SerializeField] protected Image speakerPortrait;
 
         [Header("Choice UI")][SerializeField] protected Transform choiceButtonHolder;
-        [SerializeField] protected ChoiceButton choiceButton;
+        [SerializeField] protected GameObject choiceButton;
         protected List<ChoiceButton> _choiceButtonInstances = new List<ChoiceButton>();
 
         [Header("Function Invocations")]
@@ -212,7 +212,11 @@ namespace Ibralogue
             if (_currentConversation.Choices == null || !_currentConversation.Choices.Any()) return;
             foreach (Choice choice in _currentConversation.Choices.Keys)
             {
-                ChoiceButton choiceButtonInstance = Instantiate(choiceButton, choiceButtonHolder);
+                ChoiceButton choiceButtonInstance = Instantiate(choiceButton, choiceButtonHolder).GetComponent<ChoiceButton>();
+                if (choiceButtonInstance == null)
+                {
+                    DialogueLogger.LogError(2, "ChoiceButton is null. Make sure you have the ChoiceButton component added to your Button object!");
+                }
 
                 UnityAction onClickAction = null;
                 int conversationIndex = -1;
@@ -234,16 +238,10 @@ namespace Ibralogue
                         break;
                 }
 
-
-                //ChoiceButtonHandle handle = new ChoiceButtonHandle(
-                //    choiceButtonInstance,
-                //    onClickAction
-                //);
+                choiceButtonInstance.GetComponentInChildren<TextMeshProUGUI>().text = choice.ChoiceName;
+                choiceButtonInstance.OnChoiceClick.AddListener(onClickAction);
 
                 _choiceButtonInstances.Add(choiceButtonInstance);
-
-                choiceButtonInstance.GetComponentInChildren<TextMeshProUGUI>().text = choice.ChoiceName;
-                choiceButton.ClickEvent.AddListener(choiceButton.ClickCallback);
             }
         }
 
@@ -303,7 +301,7 @@ namespace Ibralogue
 
             foreach (ChoiceButton choiceButton in _choiceButtonInstances)
             {
-                //choiceButton.ClickEvent.RemoveListener(choiceButton.ClickCallback);
+                choiceButton.OnChoiceClick.RemoveAllListeners();
                 Destroy(choiceButton.gameObject);
             }
 

--- a/Runtime/Dialogue Managers/DialogueManagerBase.cs
+++ b/Runtime/Dialogue Managers/DialogueManagerBase.cs
@@ -19,8 +19,8 @@ namespace Ibralogue
 
     public abstract class DialogueManagerBase : MonoBehaviour
     {
-        public UnityEvent OnConversationStart { get; set; } = new UnityEvent();
-        public UnityEvent OnConversationEnd { get; set; } = new UnityEvent();
+        public UnityEvent OnConversationStart = new UnityEvent();
+        public UnityEvent OnConversationEnd = new UnityEvent();
 
         public List<Conversation> ParsedConversations { get; protected set; }
         protected Conversation _currentConversation;

--- a/Runtime/Dialogue Managers/SimpleDialogueManager.cs
+++ b/Runtime/Dialogue Managers/SimpleDialogueManager.cs
@@ -1,15 +1,6 @@
-using Ibralogue.Parser;
-using TMPro;
-using UnityEngine.UI;
-
 namespace Ibralogue
 {
-    public class SimpleDialogueManager : DialogueManagerBase<Button>
+    public class SimpleDialogueManager : DialogueManagerBase
     {
-        protected override void PrepareChoiceButton(ChoiceButtonHandle handle, Choice choice)
-        {
-            handle.ChoiceButton.GetComponentInChildren<TextMeshProUGUI>().text = choice.ChoiceName;
-            handle.ClickEvent = handle.ChoiceButton.onClick;
-        }
     }
 }

--- a/Runtime/UI.meta
+++ b/Runtime/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a09fe2bc9b609494cb82f67754a05a31
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/UI/ChoiceButton.cs
+++ b/Runtime/UI/ChoiceButton.cs
@@ -1,0 +1,22 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
+
+namespace Ibralogue.UI
+{
+    public class ChoiceButton : MonoBehaviour
+    {
+        private Button _button;
+
+        public string Name { get; set; }
+        public string LeadingConversation { get; set; }
+
+        public UnityEvent ClickEvent { get; set; }
+        public UnityAction ClickCallback { get; set; }
+
+        private void Start()
+        {
+            _button = GetComponent<Button>();
+        }
+    }
+}

--- a/Runtime/UI/ChoiceButton.cs
+++ b/Runtime/UI/ChoiceButton.cs
@@ -8,15 +8,15 @@ namespace Ibralogue.UI
     {
         private Button _button;
 
-        public string Name { get; set; }
-        public string LeadingConversation { get; set; }
+        public UnityEvent OnChoiceClick { get; set; } = new UnityEvent();
 
-        public UnityEvent ClickEvent { get; set; }
-        public UnityAction ClickCallback { get; set; }
-
-        private void Start()
+        private void Awake()
         {
             _button = GetComponent<Button>();
+            _button.onClick.AddListener(OnChoiceClick.Invoke);
+
+            // TODO: In the future, all choice button handling (including setting values)
+            // will be done through this class.
         }
     }
 }

--- a/Runtime/UI/ChoiceButton.cs.meta
+++ b/Runtime/UI/ChoiceButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 252ea0cff8336ef42b10df9a76a6f398
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/DialogueManagerTests.cs
+++ b/Tests/Runtime/DialogueManagerTests.cs
@@ -1,4 +1,5 @@
 using Ibralogue.Parser;
+using Ibralogue.UI;
 using NUnit.Framework;
 using System.Collections;
 using TMPro;
@@ -15,7 +16,7 @@ namespace Ibralogue.Tests
         protected TextMeshProUGUI sentenceText;
         protected Image speakerPortrait;
         protected Transform choiceButtonHolder;
-        protected TestDialogueChoice choiceButton;
+        protected ChoiceButton choiceButton;
 
         [SetUp]
         public void BaseSetup()
@@ -28,7 +29,7 @@ namespace Ibralogue.Tests
             sentenceText = new GameObject("Sentence Text").AddComponent<TextMeshProUGUI>();
             speakerPortrait = new GameObject("Speaker Portrait").AddComponent<Image>();
             choiceButtonHolder = new GameObject("Choice Holder").transform;
-            choiceButton = new GameObject("Choice Button").AddComponent<TestDialogueChoice>();
+            choiceButton = new GameObject("Choice Button").AddComponent<ChoiceButton>();
 
             manager.ScrollSpeed = 30;
             manager.NameText = nameText;

--- a/Tests/Runtime/TestComponents/TestDialogueManager.cs
+++ b/Tests/Runtime/TestComponents/TestDialogueManager.cs
@@ -13,7 +13,7 @@ namespace Ibralogue.Tests
         public TextMeshProUGUI SentenceText { get => sentenceText; set => sentenceText = value; }
         public Image SpeakerPortrait { get => speakerPortrait; set => speakerPortrait = value; }
         public Transform ChoiceButtonHolder { get => choiceButtonHolder; set => choiceButtonHolder = value; }
-        public ChoiceButton ChoiceButton { get => choiceButton; set => choiceButton = value; }
+        public ChoiceButton ChoiceButton { get => choiceButton.GetComponent<ChoiceButton>(); set => choiceButton = value.gameObject; }
     }
 }
 

--- a/Tests/Runtime/TestComponents/TestDialogueManager.cs
+++ b/Tests/Runtime/TestComponents/TestDialogueManager.cs
@@ -1,28 +1,19 @@
 using Ibralogue.Parser;
-using System.Collections;
-using System.Collections.Generic;
+using Ibralogue.UI;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
 namespace Ibralogue.Tests
 {
-    public class TestDialogueManager : DialogueManagerBase<TestDialogueChoice>
+    public class TestDialogueManager : DialogueManagerBase
     {
         public float ScrollSpeed {  get => scrollSpeed; set => scrollSpeed = value; }
         public TextMeshProUGUI NameText { get => nameText; set => nameText = value; }
         public TextMeshProUGUI SentenceText { get => sentenceText; set => sentenceText = value; }
         public Image SpeakerPortrait { get => speakerPortrait; set => speakerPortrait = value; }
         public Transform ChoiceButtonHolder { get => choiceButtonHolder; set => choiceButtonHolder = value; }
-        public TestDialogueChoice ChoiceButton { get => choiceButton; set => choiceButton = value; }
-
-
-        protected override void PrepareChoiceButton(ChoiceButtonHandle handle, Choice choice)
-        {
-            handle.ChoiceButton.Name = choice.ChoiceName;
-            handle.ChoiceButton.LeadingConversation = choice.LeadingConversationName;
-            handle.ClickEvent = handle.ChoiceButton.Event;
-        }
+        public ChoiceButton ChoiceButton { get => choiceButton; set => choiceButton = value; }
     }
 }
 


### PR DESCRIPTION
- remove generics for ChoiceButton. DialogueManager<ChoiceButtonT> is really just not that ergonomic. more flexibility for a bring your own button sort of system in the future.
- update DefaultDialogue to omit DialogueName{{Init}}. It is no longer necessary as the parser automatically generates that name for the first conversation.
- make OnConversationStart and OnConversationEnd serialized in inspector for more flexibility